### PR TITLE
Update history to 4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "debug": "^2.2.0",
     "eslint": "^2.8.0",
     "eventemitter3": "^1.1.1",
-    "history": "^1.16.0",
+    "history": "^3.2.0",
     "path-to-regexp": "^1.2.1",
     "query-string": "^3.0.0",
     "vue": "^1.0.10"

--- a/src/state-manager.js
+++ b/src/state-manager.js
@@ -5,7 +5,7 @@ const debug = Debug('voie:manager');
 import EventEmitter from 'eventemitter3';
 import State from './state';
 import Transition from './transition';
-import { createHistory, useBasename} from 'history';
+import createHistory from 'history/createBrowserHistory';
 import './directives';
 
 /**
@@ -91,7 +91,7 @@ export default class StateManager extends EventEmitter {
       base = baseEl && baseEl.getAttribute('href');
     }
     base = (base || '').replace(/\/+$/, '');
-    this.history = useBasename(createHistory)({ basename: base });
+    this.history = createHistory({ basename: base });
   }
 
   _setupOptions(spec) {
@@ -131,14 +131,14 @@ export default class StateManager extends EventEmitter {
 
   /**
    * Executed before `enter` hooks on each state.
-   * 
+   *
    * @returns {Promise}
    */
   beforeEach() {}
 
   /**
    * Executed after `leave` hooks on each state.
-   * 
+   *
    * @returns {Promise}
    */
   afterEach() {}
@@ -305,7 +305,8 @@ export default class StateManager extends EventEmitter {
     if (this._unlisten) {
       return Promise.resolve();
     }
-    this._unlisten = this.history.listen(location => this._matchLocation(location));
+    this._matchLocation(window.location)
+    this._unlisten = this.history.listen((location, action) => {this._matchLocation(location)});
     return new Promise(resolve => this.once('history_updated', resolve));
   }
 


### PR DESCRIPTION
There's an issue with history versions inferior to 3.x.x in that Chrome on iOS hard refresh the page when used on iOS.
It was fixed in this pull request https://github.com/mjackson/history/pull/208

This fork updates the version of history used and reflects the changes done to the api.
Tested on real life application and works like a charm. Just needed to manually trigger matchLocation as listen doesn't seem to trigger when instantiated anymore.
